### PR TITLE
Fix endpoint for sets by exercise id

### DIFF
--- a/controllers/SetController.go
+++ b/controllers/SetController.go
@@ -64,9 +64,12 @@ func HandleDeleteSet(db *gorm.DB) func(*gin.Context) {
 	}
 }
 
+// HandleGetSetsForExerciseByUser | GET
+//
+// Fetch all sets for an exercise using JWT for auth
 func HandleGetSetsForExerciseByUser(db *gorm.DB, fb *firebase.App) func(*gin.Context) {
 	return func(c *gin.Context) {
-		exerciseID := c.Query("exerciseId")
+		exerciseID := c.Param("exerciseId")
 		auth, err := fb.Auth(c)
 
 		token := httputils.GetAuthTokenForRequest(c, auth)


### PR DESCRIPTION
Fix API endpoint to return the sets a user has added for a given exercise. Was previously incorrectly looking for a query param to denote the exercise, instead it should find a param in the URL